### PR TITLE
🔧 config: Se ha añadido un archivo de configuración

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
 Se ha añadido un archivo de configuración `rust-toolchain.toml` para establecer el canal nightly por defecto